### PR TITLE
[ci skip] adding user @ivanyashchuk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @kkraus14 @leofang
+* @ivanyashchuk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,5 +94,6 @@ about:
 
 extra:
   recipe-maintainers:
+    - ivanyashchuk
     - leofang
     - kkraus14


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @ivanyashchuk as instructed in #27.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #27