### PR TITLE
[ci skip] adding user @marcodomingues99

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ivanyashchuk @kkraus14
+* @marcodomingues99 @ivanyashchuk @kkraus14

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -97,4 +97,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - marcodomingues99
     - kkraus14


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @marcodomingues99 as instructed in #50.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Please contact [conda-forge/core](https://conda-forge.org/docs/maintainer/maintainer_faq.html#mfaq-contact-core) to have this PR merged, if the maintainer is unresponsive.

Fixes #50