### PR TITLE
Remove aarch64 requirement on glibc 2.28.

### DIFF
--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -23,7 +23,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
-  - cdt_name
   - docker_image

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -23,7 +23,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
-  - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -29,7 +29,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
-  - cdt_name
   - docker_image

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -29,7 +29,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
-  - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -23,7 +23,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
-  - cdt_name
   - docker_image

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -23,7 +23,7 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+  - cdt_name
   - cuda_compiler
   - cuda_compiler_version
-  - cdt_name
   - docker_image

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -65,7 +65,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
@@ -50,7 +50,7 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/build-locally.py
+++ b/build-locally.py
@@ -64,8 +64,9 @@ def verify_config(ns):
     elif ns.config.startswith("osx"):
         if "OSX_SDK_DIR" not in os.environ:
             raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=SDKs' "
-                "to download the SDK automatically to 'SDKs/MacOSX<ver>.sdk'. "
+                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+                "Note: OSX_SDK_DIR must be set to an absolute path. "
                 "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
             )
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -14,6 +14,14 @@ cxx_compiler_version:
   - 11          # [linux and ppc64le]
   - 11          # [linux and x86_64]
 
+c_stdlib_version:
+  - 2.17        # [linux and aarch64]
+  - 2.17        # [linux and ppc64le]
+  - 2.17        # [linux and x86_64]
+  - 2.17        # [linux and aarch64]
+  - 2.17        # [linux and ppc64le]
+  - 2.17        # [linux and x86_64]
+
 fortran_compiler_version:
   - 12          # [linux and aarch64]
   - 12          # [linux and ppc64le]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
   sha256: 94fc17af8e83a26cc5d231ed23981b28c29c3fc2e87b1844ea3f46486f481df5  # [win and (cuda_compiler_version or "").startswith("12")]
 
 build:
-  number: 1
+  number: 2
   skip: True  # [osx]
   skip: True  # [cuda_compiler_version == "11.2"]
   # Disable binary relocation to workaround patchelf issue
@@ -53,6 +53,9 @@ requirements:
     - {{ compiler('cuda') }}
     - arm-variant * {{ arm_variant_type }}  # [aarch64]
     - sysroot_{{ target_platform }} 2.17  # [linux]
+    # TODO: Update aarch64 to use sysroot 2.28 when compatible CI images are
+    # available on conda-forge
+    #- sysroot_{{ target_platform }} 2.28  # [aarch64]
   host:
     - cuda-version 11.0  # [(cuda_compiler_version or "").startswith("11")]
     - cuda-version 12.0  # [(cuda_compiler_version or "").startswith("12")]
@@ -66,8 +69,6 @@ requirements:
     - cuda-nvrtc        # [(cuda_compiler_version or "").startswith("12")]
     - libcublas         # [(cuda_compiler_version or "").startswith("12")]
   run_constrained:
-    - __glibc >=2.17                        # [linux and not aarch64]
-    - __glibc >=2.28                        # [linux and aarch64]
     - arm-variant * {{ arm_variant_type }}  # [aarch64]
 
 test:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

I discussed the issues in https://github.com/conda-forge/pytorch-cpu-feedstock/pull/224 with @jakirkham / @vyasr / @adibbley and we decided we would remove the `__glibc>=2.28` requirement for now. This package does need a glibc higher than 2.17 to work, but it should still be possible to use this package in build environments with older glibc versions (like in conda-forge CI). This is already a known issue for some other CUDA packages so it should be alright to have the same behavior here, until newer CI images are available in conda-forge.

Closes #58.