### PR TITLE
Align with global `zlib` pinning

### DIFF
--- a/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -27,3 +27,5 @@ zip_keys:
   - cuda_compiler
   - cuda_compiler_version
   - docker_image
+zlib:
+- '1.2'

--- a/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -27,3 +27,5 @@ zip_keys:
   - cuda_compiler
   - cuda_compiler_version
   - docker_image
+zlib:
+- '1.2'

--- a/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -33,3 +33,5 @@ zip_keys:
   - cuda_compiler
   - cuda_compiler_version
   - docker_image
+zlib:
+- '1.2'

--- a/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_aarch64_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -33,3 +33,5 @@ zip_keys:
   - cuda_compiler
   - cuda_compiler_version
   - docker_image
+zlib:
+- '1.2'

--- a/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version11cuda_compilernvcccuda_compiler_version11.8cxx_compiler_version11.yaml
@@ -27,3 +27,5 @@ zip_keys:
   - cuda_compiler
   - cuda_compiler_version
   - docker_image
+zlib:
+- '1.2'

--- a/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
+++ b/.ci_support/linux_ppc64le_c_compiler_version12cuda_compilercuda-nvcccuda_compiler_version12.0cxx_compiler_version12.yaml
@@ -27,3 +27,5 @@ zip_keys:
   - cuda_compiler
   - cuda_compiler_version
   - docker_image
+zlib:
+- '1.2'

--- a/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0.yaml
+++ b/.ci_support/win_64_cuda_compilercuda-nvcccuda_compiler_version12.0.yaml
@@ -15,3 +15,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler
   - cuda_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8.yaml
+++ b/.ci_support/win_64_cuda_compilernvcccuda_compiler_version11.8.yaml
@@ -15,3 +15,5 @@ target_platform:
 zip_keys:
 - - cuda_compiler
   - cuda_compiler_version
+zlib:
+- '1.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
   sha256: 94fc17af8e83a26cc5d231ed23981b28c29c3fc2e87b1844ea3f46486f481df5  # [win and (cuda_compiler_version or "").startswith("12")]
 
 build:
-  number: 2
+  number: 3
   skip: True  # [osx]
   skip: True  # [cuda_compiler_version == "11.2"]
   # Disable binary relocation to workaround patchelf issue

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,8 +61,8 @@ requirements:
     - cuda-version 12.0  # [(cuda_compiler_version or "").startswith("12")]
     - patchelf >=0.12  # [linux]
     # to suppress ".so not found" errors
-    - libzlib       # [linux]
-    - libzlib-wapi  # [win64]
+    - libzlib {{ zlib }}       # [linux]
+    - libzlib-wapi {{ zlib }}  # [win64]
   run:
     - {{ pin_compatible("cuda-version", max_pin="x") }}
     - cudatoolkit 11.*  # [(cuda_compiler_version or "").startswith("11")]


### PR DESCRIPTION
The recipe depends on `libzlib` and `libzlib-wapi`. However these are unconstrained in the global pinnings. As a result the latest version of these libraries gets picked up, which is now `1.3.1` ( https://github.com/conda-forge/zlib-feedstock/pull/78 ). Updated to `1.3` earlier this year ( https://github.com/conda-forge/zlib-feedstock/pull/76 )

This differs from other libraries, which use `zlib` and match the global pinnings of `zlib` (currently [at `1.2`]( https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/c7a46d58e2328ff04313e3133822ae676ba00dac/recipe/conda_build_config.yaml#L897-L898 )). As [the `run_exports` on `zlib` is fairly tight]( https://github.com/conda-forge/zlib-feedstock/blob/7e99a51a0a26a5062400ba307c96435a77dded4e/recipe/meta.yaml#L74-L77 ), `1.2` and `1.3` cannot be in the same environment. Thus the `cudnn` packages produced with latest `zlib` cannot be mixed with `python`. 

To fix this, add the `zlib` variant as a pinning for `libzlib` and `libzlib-wapi`. This ensure these will be pinned the same way `zlib` is in the global pinnings. Also this ensures re-rendering pulls in the corresponding global pinning of `zlib`. As a result `cudnn` packages built with this constraint will match the global pinnings in terms of `zlib` and be installable next to other packages using those pinnings (like `python`)

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/cudnn-feedstock/issues/81

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/pytorch-cpu-feedstock/pull/224#issuecomment-1993358085