### PR TITLE
move run_exports to correct section

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
   sha256: 214f21e4a6fdc7121b2463f55937ebf097ab7c96232c3d575b39b9b030503fca  # [win and (cuda_compiler_version or "").startswith("12")]
 
 build:
-  number: 1
+  number: 2
   skip: true  # [cuda_compiler_version in ("None", None)]
 
 requirements:
@@ -36,6 +36,9 @@ outputs:
     build:
       ignore_run_exports_from:
         - {{ compiler('cuda') }}
+      # The run_exports is present on cudnn for backward compatibility
+      run_exports:
+        - {{ pin_subpackage("cudnn", max_pin="x") }}
     requirements:
       build:
         - {{ compiler('c') }}
@@ -52,9 +55,6 @@ outputs:
         - {{ pin_subpackage("libcudnn-dev", exact=True) }}
       run_constrained:
         - cudnn-jit <0a
-      # The run_exports is present on cudnn for backward compatibility
-      run_exports:
-        - {{ pin_subpackage("cudnn", max_pin="x") }}
 
   - name: libcudnn
     build:
@@ -124,6 +124,8 @@ outputs:
     build:
       ignore_run_exports_from:
         - {{ compiler('cuda') }}
+      run_exports:
+        - {{ pin_subpackage("libcudnn", max_pin="x") }}
     files:
       - include/cudnn*.h                                                                             # [linux]
       - Library/include/cudnn*.h                                                                     # [win]
@@ -145,8 +147,6 @@ outputs:
         - {{ pin_subpackage("libcudnn", exact=True) }}
       run_constrained:
         - libcudnn-jit-dev <0a
-      run_exports:
-        - {{ pin_subpackage("libcudnn", max_pin="x") }}
     test:
       commands:
         - if not exist %LIBRARY_INC%/cudnn.h exit 1                                                  # [win]
@@ -284,6 +284,8 @@ outputs:
       skip: true # not shipping for v9.10
       ignore_run_exports_from:
         - {{ compiler('cuda') }}
+      run_exports:
+        - {{ pin_subpackage("libcudnn-jit", max_pin="x") }}
     files:
       - Library/include/cudnn*.h                                                                  # [win]
       - Library/lib/cudnn.lib                                                                     # [win]
@@ -312,8 +314,6 @@ outputs:
         - {{ pin_subpackage("libcudnn-jit", exact=True) }}
       run_constrained:
         - libcudnn-dev <0a
-      run_exports:
-        - {{ pin_subpackage("libcudnn-jit", max_pin="x") }}
     test:
       commands:
         - if not exist %LIBRARY_INC%/cudnn.h exit 1                                                  # [win]


### PR DESCRIPTION
Fix an oversight from #114 that caused the run-exports to not actually take effect, leading to the reappearance of https://github.com/conda-forge/jaxlib-feedstock/issues/312